### PR TITLE
feat(web): 增加可配置、强互动型 Web 管理界面和丰富 API

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -126,5 +126,34 @@
     "type": "int",
     "hint": "每隔多少轮对话形成一次记忆。",
     "default": 15
+  },
+  "web_ui": {
+    "description": "Web 界面",
+    "type": "object",
+    "hint": "配置内置 Web 管理界面 (实验性)",
+    "items": {
+      "enabled": {
+        "description": "启用Web界面",
+        "type": "bool",
+        "default": false,
+        "obvious_hint": true
+      },
+      "host": {
+        "description": "监听地址",
+        "type": "string",
+        "default": "127.0.0.1"
+      },
+      "port": {
+        "description": "端口",
+        "type": "int",
+        "default": 8350
+      },
+      "access_token": {
+        "description": "访问令牌(可选)",
+        "type": "string",
+        "hint": "如设置，访问 /api/* 需在 Header 中携带 x-access-token",
+        "default": ""
+      }
+    }
   }
 }

--- a/web_server.py
+++ b/web_server.py
@@ -1,0 +1,461 @@
+import os
+import json
+import asyncio
+from typing import Any, Dict, List, Optional
+
+try:
+    from aiohttp import web
+except Exception:  # pragma: no cover
+    web = None
+
+try:
+    from astrbot.api import logger
+except Exception:  # pragma: no cover
+    import logging
+    logger = logging.getLogger(__name__)
+
+from .resource_management import resource_manager
+
+
+class MemoryWebServer:
+    """
+    轻量级 Web 服务，用于浏览与管理记忆图谱。
+    提供 REST API + 简单静态页面。可通过配置启用/关闭与端口设置。
+    """
+
+    def __init__(self, memory_system: Any, host: str = "127.0.0.1", port: int = 8350, access_token: str = "") -> None:
+        if web is None:
+            raise RuntimeError("aiohttp 不可用，无法启动 Web 服务")
+        self.ms = memory_system
+        self.host = host
+        self.port = int(port)
+        self.access_token = access_token or ""
+
+        self._app = web.Application(middlewares=[self._cors_middleware, self._auth_middleware])
+        self._runner: Optional[web.AppRunner] = None
+        self._site: Optional[web.BaseSite] = None
+
+        self._setup_routes()
+
+    # ---------------------- lifecycle ----------------------
+    async def start(self):
+        self._runner = web.AppRunner(self._app)
+        await self._runner.setup()
+        self._site = web.TCPSite(self._runner, self.host, self.port)
+        await self._site.start()
+        logger.info(f"Memora Web 已启动: http://{self.host}:{self.port}")
+
+    async def stop(self):
+        try:
+            if self._runner:
+                await self._runner.cleanup()
+                logger.info("Memora Web 已停止")
+        finally:
+            self._runner = None
+            self._site = None
+
+    # ---------------------- middlewares ----------------------
+    @web.middleware
+    async def _cors_middleware(self, request: web.Request, handler):
+        if request.method == "OPTIONS":
+            resp = web.Response(status=204)
+        else:
+            resp = await handler(request)
+        # CORS headers
+        resp.headers["Access-Control-Allow-Origin"] = request.headers.get("Origin", "*")
+        resp.headers["Access-Control-Allow-Methods"] = "GET,POST,PUT,DELETE,OPTIONS"
+        resp.headers["Access-Control-Allow-Headers"] = "*, X-Requested-With, Content-Type, Authorization, x-access-token"
+        resp.headers["Access-Control-Allow-Credentials"] = "true"
+        return resp
+
+    @web.middleware
+    async def _auth_middleware(self, request: web.Request, handler):
+        # 如果设置了访问令牌，仅保护 /api 前缀
+        if self.access_token and request.path.startswith("/api/"):
+            token = request.headers.get("x-access-token") or request.query.get("token")
+            if token != self.access_token:
+                return web.json_response({"error": "unauthorized"}, status=401)
+        return await handler(request)
+
+    # ---------------------- routes ----------------------
+    def _setup_routes(self) -> None:
+        # API
+        self._app.add_routes([
+            web.get("/api/status", self.api_status),
+            web.get("/api/groups", self.api_groups),
+            web.get("/api/graph", self.api_graph),
+
+            web.get("/api/concepts", self.api_concepts),
+            web.post("/api/concepts", self.api_create_concept),
+            web.put("/api/concepts/{concept_id}", self.api_update_concept),
+            web.delete("/api/concepts/{concept_id}", self.api_delete_concept),
+
+            web.get("/api/memories", self.api_memories),
+            web.post("/api/memories", self.api_create_memory),
+            web.put("/api/memories/{memory_id}", self.api_update_memory),
+            web.delete("/api/memories/{memory_id}", self.api_delete_memory),
+
+            web.get("/api/connections", self.api_connections),
+            web.post("/api/connections", self.api_create_connection),
+            web.put("/api/connections/{conn_id}", self.api_update_connection),
+            web.delete("/api/connections/{conn_id}", self.api_delete_connection),
+
+            web.get("/api/impressions", self.api_impressions),
+            web.post("/api/impressions", self.api_create_impression),
+            web.put("/api/impressions/{person}/score", self.api_update_impression_score),
+        ])
+
+        # 静态文件
+        static_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "webui")
+        self._static_dir = static_dir
+        if not os.path.exists(static_dir):
+            os.makedirs(static_dir, exist_ok=True)
+        self._app.router.add_get("/", self.handle_index)
+        self._app.router.add_static("/static/", static_dir, show_index=True)
+
+    # ---------------------- helpers ----------------------
+    async def _load_group(self, group_id: str) -> None:
+        # 在当前对象上加载/切换内存图数据
+        # 注意：此操作会替换内存中的图，和并发消息处理存在竞争，简单版本忽略。
+        try:
+            self.ms.memory_graph = self.ms.memory_graph.__class__()
+            self.ms.load_memory_state(group_id or "")
+        except Exception as e:
+            logger.warning(f"加载分组数据失败: {e}")
+
+    def _query_all(self, sql: str, params: tuple = ()) -> List[tuple]:
+        conn = resource_manager.get_db_connection(self.ms.db_path)
+        try:
+            cur = conn.cursor()
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+            return rows
+        finally:
+            resource_manager.release_db_connection(self.ms.db_path, conn)
+
+    def _execute(self, sql: str, params: tuple = ()) -> None:
+        conn = resource_manager.get_db_connection(self.ms.db_path)
+        try:
+            cur = conn.cursor()
+            cur.execute("BEGIN TRANSACTION")
+            cur.execute(sql, params)
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            resource_manager.release_db_connection(self.ms.db_path, conn)
+
+    # ---------------------- handlers ----------------------
+    async def handle_index(self, request: web.Request):
+        index_path = os.path.join(self._static_dir, "index.html")
+        if os.path.exists(index_path):
+            return web.FileResponse(index_path)
+        return web.Response(text="Memora Web", content_type="text/plain")
+
+    async def api_status(self, request: web.Request):
+        cfg = self.ms.memory_config or {}
+        web_cfg = cfg.get("web_ui", {})
+        return web.json_response({
+            "memory_enabled": bool(getattr(self.ms, "memory_system_enabled", True)),
+            "db_path": self.ms.db_path,
+            "web_enabled": bool(web_cfg.get("enabled", False)),
+            "host": request.host,
+        })
+
+    async def api_groups(self, request: web.Request):
+        rows = self._query_all("SELECT DISTINCT group_id FROM memories WHERE group_id IS NOT NULL")
+        groups = sorted({(r[0] or "") for r in rows})
+        # 确保包含默认组(私聊/全局)
+        if "" not in groups:
+            groups = [""] + list(groups)
+        return web.json_response({"groups": groups})
+
+    async def api_graph(self, request: web.Request):
+        from .memory_graph_visualization import MemoryGraphVisualizer
+        group_id = request.query.get("group_id", "")
+        layout = request.query.get("layout", "auto")
+        try:
+            # 直接复用可视化的数据准备逻辑
+            viz = MemoryGraphVisualizer(self.ms)
+            data = await viz._prepare_graph_data(max_nodes=200, max_edges=800, edge_strength_threshold=0.01, group_id=group_id)
+            if data.get("error"):
+                return web.json_response({"error": data["error"]}, status=400)
+            return web.json_response(data)
+        except Exception as e:
+            logger.error(f"获取图数据失败: {e}")
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def api_concepts(self, request: web.Request):
+        group_id = request.query.get("group_id", "")
+        if group_id:
+            rows = self._query_all(
+                "SELECT DISTINCT c.id, c.name FROM concepts c JOIN memories m ON m.concept_id=c.id WHERE m.group_id=?",
+                (group_id,),
+            )
+        else:
+            rows = self._query_all(
+                "SELECT DISTINCT c.id, c.name FROM concepts c JOIN memories m ON m.concept_id=c.id WHERE (m.group_id='' OR m.group_id IS NULL)"
+            )
+        concepts = [{"id": r[0], "name": r[1]} for r in rows]
+        return web.json_response({"concepts": concepts})
+
+    async def api_create_concept(self, request: web.Request):
+        body = await request.json()
+        name = (body.get("name") or "").strip()
+        group_id = (body.get("group_id") or "").strip()
+        if not name:
+            return web.json_response({"error": "name required"}, status=400)
+        # 通过内存图创建，便于后续操作
+        await self._load_group(group_id)
+        cid = self.ms.memory_graph.add_concept(name)
+        await self.ms._queue_save_memory_state(group_id)
+        return web.json_response({"id": cid, "name": name})
+
+    async def api_update_concept(self, request: web.Request):
+        concept_id = request.match_info.get("concept_id")
+        body = await request.json()
+        new_name = (body.get("name") or "").strip()
+        group_id = (body.get("group_id") or "").strip()
+        if not new_name:
+            return web.json_response({"error": "name required"}, status=400)
+        await self._load_group(group_id)
+        if concept_id in self.ms.memory_graph.concepts:
+            self.ms.memory_graph.concepts[concept_id].name = new_name
+            await self.ms._queue_save_memory_state(group_id)
+            return web.json_response({"ok": True})
+        return web.json_response({"error": "concept not found"}, status=404)
+
+    async def api_delete_concept(self, request: web.Request):
+        concept_id = request.match_info.get("concept_id")
+        group_id = request.query.get("group_id", "")
+        await self._load_group(group_id)
+        if concept_id in self.ms.memory_graph.concepts:
+            self.ms.memory_graph.remove_concept(concept_id)
+            await self.ms._queue_save_memory_state(group_id)
+            return web.json_response({"ok": True})
+        return web.json_response({"error": "not found"}, status=404)
+
+    async def api_memories(self, request: web.Request):
+        group_id = request.query.get("group_id", "")
+        concept_id = request.query.get("concept_id")
+        q = request.query.get("q")
+        person = request.query.get("person")
+
+        if person:
+            # 人物印象
+            try:
+                summary = self.ms.get_person_impression_summary(group_id, person)
+                memories = self.ms.get_person_impression_memories(group_id, person, limit=50)
+                return web.json_response({"summary": summary, "memories": memories})
+            except Exception as e:
+                return web.json_response({"error": str(e)}, status=500)
+
+        if q:
+            # 搜索
+            await self._load_group(group_id)
+            mems = await self.ms.recall_memories_full(q)
+            data = [m.__dict__ for m in mems]
+            return web.json_response({"memories": data})
+
+        # 按组/概念列出
+        if concept_id:
+            rows = self._query_all(
+                "SELECT id, concept_id, content, details, participants, location, emotion, tags, created_at, last_accessed, access_count, strength FROM memories WHERE concept_id=? AND (group_id=? OR (?='' AND (group_id='' OR group_id IS NULL))) ORDER BY last_accessed DESC",
+                (concept_id, group_id, group_id),
+            )
+        else:
+            if group_id:
+                rows = self._query_all(
+                    "SELECT id, concept_id, content, details, participants, location, emotion, tags, created_at, last_accessed, access_count, strength FROM memories WHERE group_id=? ORDER BY last_accessed DESC",
+                    (group_id,),
+                )
+            else:
+                rows = self._query_all(
+                    "SELECT id, concept_id, content, details, participants, location, emotion, tags, created_at, last_accessed, access_count, strength FROM memories WHERE group_id='' OR group_id IS NULL ORDER BY last_accessed DESC"
+                )
+        memories = [
+            {
+                "id": r[0],
+                "concept_id": r[1],
+                "content": r[2],
+                "details": r[3] or "",
+                "participants": r[4] or "",
+                "location": r[5] or "",
+                "emotion": r[6] or "",
+                "tags": r[7] or "",
+                "created_at": r[8],
+                "last_accessed": r[9],
+                "access_count": r[10],
+                "strength": r[11],
+            }
+            for r in rows
+        ]
+        return web.json_response({"memories": memories})
+
+    async def api_create_memory(self, request: web.Request):
+        body = await request.json()
+        group_id = (body.get("group_id") or "").strip()
+        concept_id = (body.get("concept_id") or "").strip()
+        concept_name = (body.get("concept_name") or "").strip()
+        content = (body.get("content") or "").strip()
+        if not content:
+            return web.json_response({"error": "content required"}, status=400)
+        await self._load_group(group_id)
+        if not concept_id:
+            # 若没有传 id，使用名称新建/获取
+            if not concept_name:
+                return web.json_response({"error": "concept_id or concept_name required"}, status=400)
+            concept_id = self.ms.memory_graph.add_concept(concept_name)
+        mem_id = self.ms.memory_graph.add_memory(
+            content=content,
+            concept_id=concept_id,
+            details=(body.get("details") or ""),
+            participants=(body.get("participants") or ""),
+            location=(body.get("location") or ""),
+            emotion=(body.get("emotion") or ""),
+            tags=(body.get("tags") or ""),
+            strength=float(body.get("strength") or 1.0),
+            group_id=group_id,
+        )
+        await self.ms._queue_save_memory_state(group_id)
+        return web.json_response({"id": mem_id})
+
+    async def api_update_memory(self, request: web.Request):
+        memory_id = request.match_info.get("memory_id")
+        body = await request.json()
+        group_id = (body.get("group_id") or "").strip()
+        await self._load_group(group_id)
+        ok = self.ms.memory_graph.update_memory(
+            memory_id,
+            content=body.get("content"),
+            details=body.get("details"),
+            participants=body.get("participants"),
+            location=body.get("location"),
+            emotion=body.get("emotion"),
+            tags=body.get("tags"),
+            strength=float(body.get("strength")) if body.get("strength") is not None else None,
+            concept_id=body.get("concept_id"),
+        )
+        if not ok:
+            return web.json_response({"error": "not found"}, status=404)
+        await self.ms._queue_save_memory_state(group_id)
+        return web.json_response({"ok": True})
+
+    async def api_delete_memory(self, request: web.Request):
+        memory_id = request.match_info.get("memory_id")
+        group_id = request.query.get("group_id", "")
+        await self._load_group(group_id)
+        if memory_id in self.ms.memory_graph.memories:
+            self.ms.memory_graph.remove_memory(memory_id)
+            await self.ms._queue_save_memory_state(group_id)
+            return web.json_response({"ok": True})
+        return web.json_response({"error": "not found"}, status=404)
+
+    async def api_connections(self, request: web.Request):
+        group_id = request.query.get("group_id", "")
+        # 仅返回当前 group 的概念之间的连接
+        if group_id:
+            concept_rows = self._query_all("SELECT DISTINCT concept_id FROM memories WHERE group_id=?", (group_id,))
+        else:
+            concept_rows = self._query_all("SELECT DISTINCT concept_id FROM memories WHERE group_id='' OR group_id IS NULL")
+        cids = {r[0] for r in concept_rows}
+        rows = self._query_all("SELECT id, from_concept, to_concept, strength, last_strengthened FROM connections")
+        result = [
+            {
+                "id": r[0],
+                "from_concept": r[1],
+                "to_concept": r[2],
+                "strength": r[3],
+                "last_strengthened": r[4],
+            }
+            for r in rows
+            if r[1] in cids and r[2] in cids
+        ]
+        return web.json_response({"connections": result})
+
+    async def api_create_connection(self, request: web.Request):
+        body = await request.json()
+        group_id = (body.get("group_id") or "").strip()
+        from_c = body.get("from_concept")
+        to_c = body.get("to_concept")
+        strength = float(body.get("strength") or 1.0)
+        if not from_c or not to_c:
+            return web.json_response({"error": "from_concept and to_concept required"}, status=400)
+        await self._load_group(group_id)
+        cid = self.ms.memory_graph.add_connection(str(from_c), str(to_c), strength=strength)
+        await self.ms._queue_save_memory_state(group_id)
+        return web.json_response({"id": cid})
+
+    async def api_update_connection(self, request: web.Request):
+        conn_id = request.match_info.get("conn_id")
+        body = await request.json()
+        group_id = (body.get("group_id") or "").strip()
+        strength = body.get("strength")
+        if strength is None:
+            return web.json_response({"error": "strength required"}, status=400)
+        await self._load_group(group_id)
+        ok = self.ms.memory_graph.set_connection_strength(conn_id, float(strength))
+        if not ok:
+            return web.json_response({"error": "not found"}, status=404)
+        await self.ms._queue_save_memory_state(group_id)
+        return web.json_response({"ok": True})
+
+    async def api_delete_connection(self, request: web.Request):
+        conn_id = request.match_info.get("conn_id")
+        group_id = request.query.get("group_id", "")
+        await self._load_group(group_id)
+        self.ms.memory_graph.remove_connection(conn_id)
+        await self.ms._queue_save_memory_state(group_id)
+        return web.json_response({"ok": True})
+
+    async def api_impressions(self, request: web.Request):
+        group_id = request.query.get("group_id", "")
+        person = request.query.get("person")
+        if person:
+            try:
+                summary = self.ms.get_person_impression_summary(group_id, person)
+                memories = self.ms.get_person_impression_memories(group_id, person, limit=50)
+                return web.json_response({"summary": summary, "memories": memories})
+            except Exception as e:
+                return web.json_response({"error": str(e)}, status=500)
+        # 列出当前群的所有 Imprint 概念
+        if group_id:
+            like_prefix = f"Imprint:{group_id}:"
+        else:
+            like_prefix = "Imprint::"  # 私聊/全局
+        rows = self._query_all("SELECT id, name FROM concepts WHERE name LIKE ?", (f"{like_prefix}%",))
+        people = []
+        for r in rows:
+            name = r[1].split(":")[-1]
+            people.append({"concept_id": r[0], "name": name})
+        return web.json_response({"people": people})
+
+    async def api_create_impression(self, request: web.Request):
+        body = await request.json()
+        group_id = (body.get("group_id") or "").strip()
+        person = (body.get("person") or "").strip()
+        summary = (body.get("summary") or "").strip()
+        score = body.get("score")
+        details = (body.get("details") or "").strip()
+        if not person or not summary:
+            return web.json_response({"error": "person and summary required"}, status=400)
+        try:
+            score_val = float(score) if score is not None else None
+        except Exception:
+            score_val = None
+        _id = self.ms.record_person_impression(group_id, person, summary, score_val, details)
+        await self.ms._queue_save_memory_state(group_id)
+        return web.json_response({"id": _id, "ok": True})
+
+    async def api_update_impression_score(self, request: web.Request):
+        body = await request.json()
+        group_id = (body.get("group_id") or "").strip()
+        person = request.match_info.get("person")
+        delta = body.get("delta")
+        try:
+            new_score = self.ms.adjust_impression_score(group_id, person, float(delta))
+            await self.ms._queue_save_memory_state(group_id)
+            return web.json_response({"score": new_score})
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=400)

--- a/webui/app.js
+++ b/webui/app.js
@@ -1,0 +1,260 @@
+const state = {
+  group: "",
+  token: "",
+  concepts: [],
+  selectedConceptId: null,
+};
+
+function headers() {
+  const h = {"Content-Type": "application/json"};
+  if (state.token) h["x-access-token"] = state.token;
+  return h;
+}
+
+async function fetchJson(url, opts = {}) {
+  const res = await fetch(url, {headers: headers(), ...opts});
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+function qs(sel) { return document.querySelector(sel); }
+
+async function loadGroups() {
+  const data = await fetchJson(`/api/groups`);
+  const sel = qs('#groupSelect');
+  sel.innerHTML = '';
+  for (const g of data.groups) {
+    const opt = document.createElement('option');
+    opt.value = g;
+    opt.textContent = g || '(默认/私聊)';
+    sel.appendChild(opt);
+  }
+  sel.value = state.group;
+}
+
+async function loadGraph() {
+  const data = await fetchJson(`/api/graph?group_id=${encodeURIComponent(state.group)}`);
+  const nodes = data.nodes.map(n => ({ data: { id: n.id, label: `${n.name}(${n.count})` } }));
+  const edges = data.edges.map(e => ({ data: { id: `${e.from_concept}_${e.to_concept}`, source: e.from_concept, target: e.to_concept, weight: e.strength } }));
+  const cy = cytoscape({
+    container: document.getElementById('graph'),
+    elements: { nodes, edges },
+    style: [
+      { selector: 'node', style: { 'label': 'data(label)', 'background-color': '#64b5f6', 'font-size': 10 } },
+      { selector: 'edge', style: { 'width': 2, 'line-color': '#bbb' } },
+    ],
+    layout: { name: 'cose', fit: true }
+  });
+  cy.on('tap', 'node', (evt) => {
+    const id = evt.target.id();
+    state.selectedConceptId = id;
+    render();
+    loadMemories();
+  });
+}
+
+async function loadConcepts() {
+  const data = await fetchJson(`/api/concepts?group_id=${encodeURIComponent(state.group)}`);
+  state.concepts = data.concepts || [];
+  render();
+}
+
+async function loadMemories() {
+  const params = new URLSearchParams();
+  params.set('group_id', state.group);
+  if (state.selectedConceptId) params.set('concept_id', state.selectedConceptId);
+  const data = await fetchJson(`/api/memories?${params}`);
+  const list = qs('#memoryList');
+  list.innerHTML = '';
+  for (const m of data.memories) {
+    const el = document.createElement('div');
+    el.className = 'item';
+    const left = document.createElement('div');
+    left.innerHTML = `<div>${m.content}</div><small>强度:${m.strength?.toFixed?.(2) ?? m.strength} 概念:${m.concept_id}</small>`;
+    const act = document.createElement('div');
+    act.className = 'actions';
+
+    const editBtn = document.createElement('button');
+    editBtn.className = 'small';
+    editBtn.textContent = '编辑';
+    editBtn.onclick = async () => {
+      const content = prompt('内容', m.content);
+      if (content == null) return;
+      await fetchJson(`/api/memories/${m.id}`, {method: 'PUT', body: JSON.stringify({group_id: state.group, content})});
+      loadMemories();
+    };
+    const strengthBtn = document.createElement('button');
+    strengthBtn.className = 'small';
+    strengthBtn.textContent = '强度';
+    strengthBtn.onclick = async () => {
+      const s = prompt('强度(0-1)', m.strength);
+      if (s == null) return;
+      await fetchJson(`/api/memories/${m.id}`, {method: 'PUT', body: JSON.stringify({group_id: state.group, strength: parseFloat(s)})});
+      loadMemories();
+    };
+    const delBtn = document.createElement('button');
+    delBtn.className = 'small danger';
+    delBtn.textContent = '删除';
+    delBtn.onclick = async () => {
+      if (!confirm('确认删除?')) return;
+      await fetchJson(`/api/memories/${m.id}?group_id=${encodeURIComponent(state.group)}`, {method: 'DELETE'});
+      loadMemories();
+    };
+
+    act.appendChild(editBtn);
+    act.appendChild(strengthBtn);
+    act.appendChild(delBtn);
+    el.appendChild(left);
+    el.appendChild(act);
+    list.appendChild(el);
+  }
+}
+
+async function loadConnections() {
+  const data = await fetchJson(`/api/connections?group_id=${encodeURIComponent(state.group)}`);
+  const list = qs('#connList');
+  list.innerHTML = '';
+  for (const c of data.connections) {
+    const el = document.createElement('div');
+    el.className = 'item';
+    const left = document.createElement('div');
+    left.innerHTML = `<div>${c.from_concept} -> ${c.to_concept}</div><small>强度:${c.strength.toFixed?.(2) ?? c.strength}</small>`;
+    const act = document.createElement('div');
+    act.className = 'actions';
+    const sBtn = document.createElement('button'); sBtn.className='small'; sBtn.textContent='强度';
+    sBtn.onclick = async () => {
+      const s = prompt('强度(0-1)', c.strength);
+      if (s == null) return;
+      await fetchJson(`/api/connections/${c.id}`, {method:'PUT', body: JSON.stringify({group_id: state.group, strength: parseFloat(s)})});
+      loadConnections();
+    };
+    const dBtn = document.createElement('button'); dBtn.className='small danger'; dBtn.textContent='删除';
+    dBtn.onclick = async () => {
+      if (!confirm('确认删除?')) return;
+      await fetchJson(`/api/connections/${c.id}?group_id=${encodeURIComponent(state.group)}`, {method:'DELETE'});
+      loadConnections();
+    };
+    act.appendChild(sBtn); act.appendChild(dBtn);
+    el.appendChild(left); el.appendChild(act);
+    list.appendChild(el);
+  }
+}
+
+async function loadImpressions() {
+  const data = await fetchJson(`/api/impressions?group_id=${encodeURIComponent(state.group)}`);
+  const list = qs('#impList');
+  list.innerHTML = '';
+  for (const p of (data.people||[])) {
+    const el = document.createElement('div');
+    el.className = 'item';
+    el.innerHTML = `<div>${p.name}</div>`;
+    list.appendChild(el);
+  }
+}
+
+function renderConcepts() {
+  const list = qs('#conceptList');
+  list.innerHTML = '';
+  for (const c of state.concepts) {
+    const el = document.createElement('div');
+    el.className = 'item';
+    const left = document.createElement('div');
+    left.innerHTML = `<div>${c.name}</div><small>${c.id}</small>`;
+    const act = document.createElement('div');
+    act.className = 'actions';
+    const useBtn = document.createElement('button'); useBtn.className='small'; useBtn.textContent='选中';
+    useBtn.onclick = () => { state.selectedConceptId = c.id; render(); loadMemories(); };
+    const renameBtn = document.createElement('button'); renameBtn.className='small'; renameBtn.textContent='重命名';
+    renameBtn.onclick = async () => {
+      const name = prompt('新名称', c.name);
+      if (name == null) return;
+      await fetchJson(`/api/concepts/${c.id}`, {method:'PUT', body: JSON.stringify({group_id: state.group, name})});
+      loadConcepts();
+    };
+    const delBtn = document.createElement('button'); delBtn.className='small danger'; delBtn.textContent='删除';
+    delBtn.onclick = async () => {
+      if (!confirm('确认删除概念及其记忆?')) return;
+      await fetchJson(`/api/concepts/${c.id}?group_id=${encodeURIComponent(state.group)}`, {method:'DELETE'});
+      loadConcepts(); loadMemories(); loadGraph();
+    };
+    act.appendChild(useBtn); act.appendChild(renameBtn); act.appendChild(delBtn);
+    el.appendChild(left); el.appendChild(act);
+    list.appendChild(el);
+  }
+}
+
+function render() {
+  renderConcepts();
+}
+
+async function main() {
+  state.token = qs('#tokenInput').value.trim();
+  await loadGroups();
+  await loadConcepts();
+  await loadGraph();
+  await loadConnections();
+  await loadImpressions();
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  const groupSel = qs('#groupSelect');
+  groupSel.addEventListener('change', () => { state.group = groupSel.value; main(); });
+  qs('#tokenInput').addEventListener('change', () => { state.token = qs('#tokenInput').value.trim(); main(); });
+  qs('#refreshBtn').addEventListener('click', () => main());
+
+  qs('#addConceptBtn').addEventListener('click', async () => {
+    const name = qs('#newConceptName').value.trim();
+    if (!name) return;
+    await fetchJson('/api/concepts', {method:'POST', body: JSON.stringify({group_id: state.group, name})});
+    qs('#newConceptName').value = '';
+    await loadConcepts(); await loadGraph();
+  });
+
+  qs('#addMemoryBtn').addEventListener('click', async () => {
+    if (!state.selectedConceptId) { alert('请先在左侧选择一个概念'); return; }
+    const body = {
+      group_id: state.group,
+      concept_id: state.selectedConceptId,
+      content: qs('#memContent').value,
+      details: qs('#memDetails').value,
+      participants: qs('#memParticipants').value,
+      tags: qs('#memTags').value,
+      emotion: qs('#memEmotion').value,
+      location: qs('#memLocation').value,
+      strength: parseFloat(qs('#memStrength').value || '1')
+    };
+    if (!body.content) return;
+    await fetchJson('/api/memories', {method:'POST', body: JSON.stringify(body)});
+    ['#memContent','#memDetails','#memParticipants','#memTags','#memEmotion','#memLocation','#memStrength'].forEach(id=>qs(id).value='');
+    await loadMemories(); await loadGraph();
+  });
+
+  qs('#addConnBtn').addEventListener('click', async () => {
+    const body = {
+      group_id: state.group,
+      from_concept: qs('#connFrom').value.trim(),
+      to_concept: qs('#connTo').value.trim(),
+      strength: parseFloat(qs('#connStrength').value || '1')
+    };
+    if (!body.from_concept || !body.to_concept) return;
+    await fetchJson('/api/connections', {method:'POST', body: JSON.stringify(body)});
+    ['#connFrom','#connTo','#connStrength'].forEach(id=>qs(id).value='');
+    await loadConnections(); await loadGraph();
+  });
+
+  qs('#addImpBtn').addEventListener('click', async () => {
+    const body = {
+      group_id: state.group,
+      person: qs('#impPerson').value.trim(),
+      summary: qs('#impSummary').value.trim(),
+      score: parseFloat(qs('#impScore').value || ''),
+      details: qs('#impDetails').value.trim()
+    };
+    if (!body.person || !body.summary) return;
+    await fetchJson('/api/impressions', {method:'POST', body: JSON.stringify(body)});
+    ['#impPerson','#impSummary','#impScore','#impDetails'].forEach(id=>qs(id).value='');
+    await loadImpressions(); await loadGraph();
+  });
+
+  main();
+});

--- a/webui/index.html
+++ b/webui/index.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Memora Connect Web</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <script src="https://unpkg.com/cytoscape@3.26.0/dist/cytoscape.min.js"></script>
+</head>
+<body>
+  <header>
+    <h1>Memora Connect Web</h1>
+    <div class="toolbar">
+      <label>访问令牌: <input type="password" id="tokenInput" placeholder="如果配置了 access_token 则需填写"></label>
+      <label>群组: <select id="groupSelect"></select></label>
+      <button id="refreshBtn">刷新</button>
+    </div>
+  </header>
+
+  <main>
+    <section class="panel">
+      <h2>记忆图谱</h2>
+      <div id="graph"></div>
+    </section>
+    <section class="panel">
+      <h2>概念与记忆</h2>
+      <div class="two-col">
+        <div>
+          <h3>概念</h3>
+          <div class="list" id="conceptList"></div>
+          <div class="form">
+            <input type="text" id="newConceptName" placeholder="新概念名称">
+            <button id="addConceptBtn">添加概念</button>
+          </div>
+        </div>
+        <div>
+          <h3>记忆</h3>
+          <div class="form">
+            <input type="text" id="memContent" placeholder="内容">
+            <input type="text" id="memDetails" placeholder="细节">
+            <input type="text" id="memParticipants" placeholder="参与者">
+            <input type="text" id="memTags" placeholder="标签">
+            <input type="text" id="memEmotion" placeholder="情感">
+            <input type="text" id="memLocation" placeholder="地点">
+            <input type="number" id="memStrength" placeholder="强度(0-1)" step="0.1" min="0" max="1">
+            <button id="addMemoryBtn">添加记忆(使用选中概念)</button>
+          </div>
+          <div class="list" id="memoryList"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>连接</h2>
+      <div class="form">
+        <input type="text" id="connFrom" placeholder="from 概念ID">
+        <input type="text" id="connTo" placeholder="to 概念ID">
+        <input type="number" id="connStrength" placeholder="强度(0-1)" value="1" step="0.1" min="0" max="1">
+        <button id="addConnBtn">添加连接</button>
+      </div>
+      <div class="list" id="connList"></div>
+    </section>
+
+    <section class="panel">
+      <h2>人物印象</h2>
+      <div class="form">
+        <input type="text" id="impPerson" placeholder="人物">
+        <input type="text" id="impSummary" placeholder="摘要">
+        <input type="number" id="impScore" placeholder="分数(0-1)" step="0.1" min="0" max="1">
+        <input type="text" id="impDetails" placeholder="详细">
+        <button id="addImpBtn">记录/更新印象</button>
+      </div>
+      <div class="list" id="impList"></div>
+    </section>
+  </main>
+
+  <footer>
+    <small>Memora Connect Web UI</small>
+  </footer>
+
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/webui/style.css
+++ b/webui/style.css
@@ -1,0 +1,21 @@
+* { box-sizing: border-box; }
+body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; margin: 0; background: #f6f7fb; color: #222; }
+header { background: #2b3a67; color: #fff; padding: 12px 16px; }
+h1 { margin: 0 0 8px; font-size: 18px; }
+.toolbar { display: flex; gap: 12px; align-items: center; }
+.toolbar input, .toolbar select { padding: 4px 6px; }
+main { display: grid; grid-template-columns: 1fr; gap: 16px; padding: 16px; }
+.panel { background: #fff; border-radius: 8px; padding: 12px; box-shadow: 0 2px 8px rgba(0,0,0,.06); }
+.panel h2 { margin-top: 0; font-size: 16px; }
+#graph { width: 100%; height: 380px; background: #fafafa; border: 1px solid #e5e7ef; border-radius: 6px; }
+.two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.form { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin-bottom: 12px; }
+.form input { padding: 6px 8px; border: 1px solid #d7d9e0; border-radius: 6px; }
+.form button { padding: 8px 12px; border: none; background: #2b3a67; color: #fff; border-radius: 6px; cursor: pointer; }
+.list { display: grid; gap: 6px; max-height: 260px; overflow: auto; border: 1px dashed #e1e3ea; padding: 8px; border-radius: 6px; background: #fbfcff; }
+.item { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 6px; border: 1px solid #eee; border-radius: 6px; background: #fff; }
+.item small { color: #666; }
+.item .actions { display: flex; gap: 6px; }
+button.small { background: #4b83f5; padding: 4px 8px; font-size: 12px; }
+button.danger { background: #da4b4b; }
+footer { text-align: center; padding: 12px; color: #666; }


### PR DESCRIPTION
### Summary
本 PR 增加了供用户通过网页完整管理与互动记忆图谱的 Web UI，极大提升了交互性与可操作性。相关 API 支持在线增加、查询、编辑、删除记忆、概念、连接、印象等。

### Details
- 新增基于 aiohttp 的 MemoryWebServer，支持 RESTful API 和交互页面 webui（Cytoscape 可视图）。
- 前端支持查看/编辑/删除/添加记忆节点、概念、连接、人物印象，支持强度调整、分组选择、群聊隔离。
- 配置文件 _conf_schema.json 增加 web_ui 对象（enabled/host/port/access_token等），支持面板动态控制。
- MemoryGraph 增补 update_memory/set_connection_strength/remove_concept 等方法，支撑 WebAPI。
- 插件模块自动检测配置并按需启动或关闭 Web 服务，保证安全性和易用性。
- 所有操作均实时持久化，安全护航资源释放与关闭。