### PR TITLE
docs(readme): 更新 Memora Connect README 版本为 v0.2.6，并标记当前版本

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="center">
 
 ![AstrBot Memora Connect](https://img.shields.io/badge/AstrBot-Memora%20Connect-blue?style=for-the-badge&logo=robot&logoColor=white)
-![Version](https://img.shields.io/badge/version-v0.2.3-green?style=for-the-badge)
+![Version](https://img.shields.io/badge/version-v0.2.6-green?style=for-the-badge)
 
 **模仿人类记忆方式的智能记忆插件**
 
@@ -511,10 +511,10 @@ A: 人物印象功能的使用方法：
 
 ## 📈 版本历史
 
-### v0.2.6
+### v0.2.6 (当前版本)
 - fix 修复写法问题，优化传递llm参数
 
-### v0.2.3 (当前版本)
+### v0.2.3
 - ✨ 新增嵌入向量缓存管理
 - 🚀 性能优化和异步处理改进
 - 🐛 修复群聊隔离的若干问题


### PR DESCRIPTION
### Summary
此次提交通过更新 README 来同步新版本信息，将当前版本标记为 v0.2.6，并调整版本历史以便区分当前版本与历史版本。

### Details
- 更新头部版本徽章为 v0.2.6。
- 将 v0.2.6 标记为当前版本（当前版本）。
- 将 v0.2.3 的条目从当前版本中移除标记，更新版本历史组织结构。
- 保持与 metadata.yaml 的版本信息一致性，确保文档与元数据对齐。
