### PR TITLE
fix: 修复 SQLite "attempt to write a readonly database" 连接泄露

### DIFF
--- a/core/memory_system.py
+++ b/core/memory_system.py
@@ -125,7 +125,7 @@ class MemorySystem:
         self._save_cache = {}  # 保存缓存 {group_id: pending_changes}
         self._save_locks = {}  # 保存锁 {group_id: asyncio.Lock}
         self._last_save_time = {}  # 最后保存时间 {group_id: timestamp}
-        self._pending_save_task = None  # 待处理的保存任务
+        self._pending_save_tasks: dict[str, asyncio.Task] = {}  # 按 group_id 分的待处理保存任务
 
         # 异步任务生命周期管理 - 新增
         self._managed_tasks = set()  # 管理的异步任务集合
@@ -255,24 +255,27 @@ class MemorySystem:
             if group_id not in self._save_locks:
                 self._save_locks[group_id] = asyncio.Lock()
 
-            # 获取最后保存时间
-            last_save = self._last_save_time.get(group_id, 0)
-            current_time = time.time()
+            async with self._save_locks[group_id]:
+                # 获取最后保存时间
+                last_save = self._last_save_time.get(group_id, 0)
+                current_time = time.time()
 
-            # 如果距离上次保存时间少于2秒，延迟保存
-            if current_time - last_save < 2:
-                # 取消之前的保存任务
-                if self._pending_save_task and not self._pending_save_task.done():
-                    self._pending_save_task.cancel()
+                # 如果距离上次保存时间少于2秒，延迟保存
+                if current_time - last_save < 2:
+                    # 取消该 group_id 之前的保存任务
+                    if group_id in self._pending_save_tasks:
+                        old_task = self._pending_save_tasks[group_id]
+                        if not old_task.done():
+                            old_task.cancel()
 
-                # 创建新的延迟保存任务
-                self._pending_save_task = asyncio.create_task(
-                    self._delayed_save(group_id, current_time)
-                )
-            else:
-                # 立即保存
-                await self.save_memory_state(group_id)
-                self._last_save_time[group_id] = current_time
+                    # 创建新的延迟保存任务
+                    self._pending_save_tasks[group_id] = asyncio.create_task(
+                        self._delayed_save(group_id, current_time)
+                    )
+                else:
+                    # 立即保存
+                    await self.save_memory_state(group_id)
+                    self._last_save_time[group_id] = current_time
 
         except Exception as e:
             self._debug_log(f"队列保存失败: {e}", "warning")
@@ -723,6 +726,7 @@ class MemorySystem:
             self._debug_log(f"保存过程异常: {e}", "error")
 
     async def delete_memory_by_id(self, memory_id: str, group_id: str = "") -> bool:
+        conn = None
         try:
             if not memory_id:
                 return False
@@ -748,17 +752,27 @@ class MemorySystem:
             deleted_rows = cursor.rowcount
             conn.commit()
             resource_manager.release_db_connection(db_path, conn)
+            conn = None  # 已释放
 
             if self.embedding_cache:
                 await self.embedding_cache.delete_embedding(memory_id, group_id)
 
             return removed_from_graph or deleted_rows > 0
         except Exception as e:
+            if conn:
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
             self._debug_log(f"删除记忆失败: {e}", "error")
             return False
+        finally:
+            if conn:
+                resource_manager.release_db_connection(db_path, conn)
 
     async def _ensure_database_structure(self, db_path: str):
         """确保数据库和所需的表结构存在"""
+        conn = None
         try:
             conn = resource_manager.get_db_connection(db_path)
             cursor = conn.cursor()
@@ -772,6 +786,7 @@ class MemorySystem:
                 self._migrate_legacy_to_elements(cursor, conn, db_path)
                 conn.commit()
                 resource_manager.release_db_connection(db_path, conn)
+                conn = None  # 已释放，避免 finally 重复释放
                 self.memory_graph = MemoryGraph()
                 self.load_memory_state("")
                 return
@@ -861,10 +876,19 @@ class MemorySystem:
 
             conn.commit()
             resource_manager.release_db_connection(db_path, conn)
+            conn = None  # 已释放，避免 finally 重复释放
 
         except Exception as e:
+            if conn:
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
             self._debug_log(f"确保数据库结构异常: {e}", "error")
             raise
+        finally:
+            if conn:
+                resource_manager.release_db_connection(db_path, conn)
 
     def _migrate_legacy_to_elements(self, cursor, conn, db_path: str):
         """将旧 concepts/memories/connections 表迁移到 elements 体系"""

--- a/core/memory_system.py
+++ b/core/memory_system.py
@@ -428,6 +428,10 @@ class MemorySystem:
         conn = None
         try:
             conn = resource_manager.get_db_connection(db_path)
+            try:
+                conn.rollback()
+            except Exception:
+                pass
             cursor = conn.cursor()
 
             cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
@@ -597,6 +601,11 @@ class MemorySystem:
             db_path = self._get_group_db_path(group_id)
             await self._ensure_database_structure(db_path)
             conn = resource_manager.get_db_connection(db_path)
+            # 清理连接池复用的脏连接可能残留的未提交事务
+            try:
+                conn.rollback()
+            except Exception:
+                pass
             cursor = conn.cursor()
             cursor.execute("BEGIN TRANSACTION")
 
@@ -742,6 +751,10 @@ class MemorySystem:
             db_path = self._get_group_db_path(group_id)
             await self._ensure_database_structure(db_path)
             conn = resource_manager.get_db_connection(db_path)
+            try:
+                conn.rollback()
+            except Exception:
+                pass
             cursor = conn.cursor()
 
             if group_id:

--- a/core/memory_system.py
+++ b/core/memory_system.py
@@ -715,6 +715,7 @@ class MemorySystem:
 
                 conn.commit()
                 resource_manager.release_db_connection(db_path, conn)
+                conn = None  # 已释放，防止后续异常触发二次释放
 
                 group_info = f" (群: {group_id})" if group_id else ""
                 self._debug_log(
@@ -723,11 +724,12 @@ class MemorySystem:
                 )
 
             except BaseException as e:
-                try:
-                    conn.rollback()
-                except Exception:
-                    pass
-                resource_manager.release_db_connection(db_path, conn)
+                if conn is not None:
+                    try:
+                        conn.rollback()
+                    except Exception:
+                        pass
+                    resource_manager.release_db_connection(db_path, conn)
                 if isinstance(e, Exception):
                     self._debug_log(f"保存失败: {e}", "error")
                 raise

--- a/core/memory_system.py
+++ b/core/memory_system.py
@@ -290,12 +290,12 @@ class MemorySystem:
             if self._last_save_time.get(group_id, 0) > creation_time:
                 return  # 如果有更新的请求，跳过这次保存
 
-            # 执行实际保存
-            await self.save_memory_state(group_id)
+            # 执行实际保存（shield 防止 cancel 打断数据库写入导致连接泄露）
+            await asyncio.shield(self.save_memory_state(group_id))
             self._last_save_time[group_id] = time.time()
 
         except asyncio.CancelledError:
-            pass  # 任务被取消，正常情况
+            pass  # 在 sleep 期间被取消，正常情况
         except Exception as e:
             self._debug_log(f"延迟保存失败: {e}", "warning")
 
@@ -713,17 +713,20 @@ class MemorySystem:
                     "debug",
                 )
 
-            except Exception as e:
+            except BaseException as e:
                 try:
                     conn.rollback()
-                except Exception as rollback_e:
-                    self._debug_log(f"回滚失败: {rollback_e}", "error")
+                except Exception:
+                    pass
                 resource_manager.release_db_connection(db_path, conn)
-                self._debug_log(f"保存失败: {e}", "error")
+                if isinstance(e, Exception):
+                    self._debug_log(f"保存失败: {e}", "error")
                 raise
 
-        except Exception as e:
-            self._debug_log(f"保存过程异常: {e}", "error")
+        except BaseException as e:
+            if isinstance(e, Exception):
+                self._debug_log(f"保存过程异常: {e}", "error")
+            raise
 
     async def delete_memory_by_id(self, memory_id: str, group_id: str = "") -> bool:
         conn = None

--- a/main.py
+++ b/main.py
@@ -499,21 +499,17 @@ class MemoraConnectPlugin(Star):
                 await self.memory_system._cancel_all_managed_tasks()
 
             # 3. 等待待处理的保存任务完成
-            if (
-                hasattr(self.memory_system, "_pending_save_task")
-                and self.memory_system._pending_save_task
-                and not self.memory_system._pending_save_task.done()
-            ):
-                try:
-                    await asyncio.wait_for(
-                        self.memory_system._pending_save_task, timeout=5.0
-                    )
-                except asyncio.TimeoutError:
-                    self.memory_system._pending_save_task.cancel()
-                    try:
-                        await self.memory_system._pending_save_task
-                    except asyncio.CancelledError:
-                        pass
+            if hasattr(self.memory_system, "_pending_save_tasks"):
+                for task in list(self.memory_system._pending_save_tasks.values()):
+                    if task and not task.done():
+                        try:
+                            await asyncio.wait_for(task, timeout=5.0)
+                        except asyncio.TimeoutError:
+                            task.cancel()
+                            try:
+                                await task
+                            except asyncio.CancelledError:
+                                pass
 
             # 4. 清理嵌入向量缓存
             if (


### PR DESCRIPTION
✏️ 问题描述

插件运行一段时间后，日志反复出现：

保存失败: attempt to write a readonly database
保存过程异常: attempt to write a readonly database

错误一旦出现就持续不断，只能重启进程恢复。

✏️ 根因分析

经过排查定位到四个问题，形成因果链：

_ensure_database_structure() 执行 DDL 异常
  → conn 未 rollback、未 release
  → 磁盘残留 journal 文件
  → 下次 save_memory_state → conn.commit()
  → SQLite 检测 journal 冲突 → 降级只读
  → 💥 readonly database

具体四个问题：

# | 位置                         | 问题                                             
--+----------------------------+------------------------------------------------
1 | _ensure_database_structure | conn 在 try 内部声明，异常时无 rollback、无 finally 释放，连接泄露
2 | delete_memory_by_id        | 同上，异常路径无 rollback 和连接释放                        
3 | _queue_save_memory_state   | _pending_save_task 是单例，多次快速保存时前一个 task 被覆盖丢失   
4 | _queue_save_memory_state   | asyncio.Lock 创建了但从未 async with，等于没用            

✏️ 修复内容

1. _ensure_database_structure — conn 提前声明，异常分支加 conn.rollback()，加 finally 块释放连接
2. delete_memory_by_id — 同上模式
3. _pending_save_task → _pending_save_tasks: dict[str, Task]，按 group_id 分发任务，避免覆盖
4. _queue_save_memory_state — async with self._save_locks[group_id] 包裹临界区
✏️ 验证

修复前：运行数小时后日志出现 readonly database，之后每条消息都触发。
修复后：重载插件后正常运行，grep "readonly database" 返回空。